### PR TITLE
Add dashboardSuperadmin view and backend

### DIFF
--- a/controlador/DashboardSuperadminController.php
+++ b/controlador/DashboardSuperadminController.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+require_once '../modelos/Dashboard.php';
+$dash = new Dashboard();
+
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'resumen':
+        echo json_encode($dash->resumen());
+        break;
+    default:
+        http_response_code(400);
+        echo json_encode(['status'=>'error','msg'=>'Operación desconocida']);
+}

--- a/modelos/Dashboard.php
+++ b/modelos/Dashboard.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__.'/../config/Conexion.php';
+
+class Dashboard
+{
+    public function resumen(): array
+    {
+        $tablas = [
+            'clientes'    => 'cliente',
+            'proveedores' => 'proveedor',
+            'articulos'   => 'articulo',
+            'usuarios'    => 'usuario'
+        ];
+
+        $data = [];
+        foreach ($tablas as $key => $tbl) {
+            $row = ejecutarConsultaSimpleFila("SELECT COUNT(*) AS total FROM $tbl");
+            $data[$key] = (int)($row['total'] ?? 0);
+        }
+        return $data;
+    }
+}

--- a/vistas/dashboardSuperadmin.php
+++ b/vistas/dashboardSuperadmin.php
@@ -1,0 +1,47 @@
+<?php
+$pageTitle = 'Dashboard';
+require 'layout/header.php';
+require 'layout/navbar.php';
+require 'layout/sidebar.php';
+?>
+<div class="container-fluid pt-4">
+  <div class="row">
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Clientes</h5>
+          <p class="display-4" id="countClientes">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Proveedores</h5>
+          <p class="display-4" id="countProveedores">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Artículos</h5>
+          <p class="display-4" id="countArticulos">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Usuarios</h5>
+          <p class="display-4" id="countUsuarios">0</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php require 'layout/footer.php'; ?>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+</script>
+<script src="<?= APP_URL ?>vistas/js/dashboardSuperadmin.js"></script>

--- a/vistas/js/dashboardSuperadmin.js
+++ b/vistas/js/dashboardSuperadmin.js
@@ -1,0 +1,10 @@
+$(function(){
+  const base = window.BASE_URL || '';
+  $.getJSON(base + 'controlador/DashboardSuperadminController.php?op=resumen')
+    .done(data => {
+      $('#countClientes').text(data.clientes || 0);
+      $('#countProveedores').text(data.proveedores || 0);
+      $('#countArticulos').text(data.articulos || 0);
+      $('#countUsuarios').text(data.usuarios || 0);
+    });
+});


### PR DESCRIPTION
## Summary
- implement `Dashboard` model to fetch counts for key tables
- add `DashboardSuperadminController` returning summary data in JSON
- create `dashboardSuperadmin.php` view with cards for counts
- add JavaScript to load dashboard data

## Testing
- `php` binary not found, so PHP syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_6862c817627483278080b64bcfdb68db