### PR TITLE
Add module dashboards

### DIFF
--- a/config/menu.php
+++ b/config/menu.php
@@ -5,7 +5,9 @@ $menu = [
     'dashboard' => [
         'icon' => 'fas fa-home',
         'items' => [
-            ['label' => 'Principal', 'view' => 'dashboardSuperadmin']
+            ['label' => 'Principal',   'view' => 'dashboardSuperadmin'],
+            ['label' => 'Inventario',  'view' => 'dashboardInventario'],
+            ['label' => 'Seguridad',   'view' => 'dashboardSeguridad']
         ]
     ],
     'administracion' => [

--- a/controlador/DashboardModuloController.php
+++ b/controlador/DashboardModuloController.php
@@ -1,0 +1,34 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+require_once '../modelos/Dashboard.php';
+$dash = new Dashboard();
+
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'inventario':
+        $tablas = [
+            'articulos'   => 'articulo',
+            'movimientos' => 'almacen_movimiento',
+            'marcas'      => 'marca',
+            'lineas'      => 'linea'
+        ];
+        echo json_encode($dash->resumenPorTablas($tablas));
+        break;
+
+    case 'seguridad':
+        $tablas = [
+            'usuarios' => 'usuario',
+            'roles'    => 'rol',
+            'permisos' => 'permiso',
+            'modulos'  => 'modulo'
+        ];
+        echo json_encode($dash->resumenPorTablas($tablas));
+        break;
+
+    default:
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'msg' => 'Operación desconocida']);
+}

--- a/modelos/Dashboard.php
+++ b/modelos/Dashboard.php
@@ -19,4 +19,18 @@ class Dashboard
         }
         return $data;
     }
+
+    /**
+     * Devuelve el conteo de registros para las tablas indicadas.
+     * @param array $tablas Arreglo asociativo nombre=>tabla
+     */
+    public function resumenPorTablas(array $tablas): array
+    {
+        $data = [];
+        foreach ($tablas as $key => $tbl) {
+            $row = ejecutarConsultaSimpleFila("SELECT COUNT(*) AS total FROM $tbl");
+            $data[$key] = (int)($row['total'] ?? 0);
+        }
+        return $data;
+    }
 }

--- a/vistas/dashboardInventario.php
+++ b/vistas/dashboardInventario.php
@@ -1,0 +1,47 @@
+<?php
+$pageTitle = 'Dashboard Inventario';
+require 'layout/header.php';
+require 'layout/navbar.php';
+require 'layout/sidebar.php';
+?>
+<div class="container-fluid pt-4">
+  <div class="row">
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Artículos</h5>
+          <p class="display-4" id="countArticulos">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Movimientos</h5>
+          <p class="display-4" id="countMovimientos">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Marcas</h5>
+          <p class="display-4" id="countMarcas">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Líneas</h5>
+          <p class="display-4" id="countLineas">0</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php require 'layout/footer.php'; ?>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+</script>
+<script src="<?= APP_URL ?>vistas/js/dashboardInventario.js"></script>

--- a/vistas/dashboardSeguridad.php
+++ b/vistas/dashboardSeguridad.php
@@ -1,0 +1,47 @@
+<?php
+$pageTitle = 'Dashboard Seguridad';
+require 'layout/header.php';
+require 'layout/navbar.php';
+require 'layout/sidebar.php';
+?>
+<div class="container-fluid pt-4">
+  <div class="row">
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Usuarios</h5>
+          <p class="display-4" id="countUsuarios">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Roles</h5>
+          <p class="display-4" id="countRoles">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Permisos</h5>
+          <p class="display-4" id="countPermisos">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Módulos</h5>
+          <p class="display-4" id="countModulos">0</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php require 'layout/footer.php'; ?>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+</script>
+<script src="<?= APP_URL ?>vistas/js/dashboardSeguridad.js"></script>

--- a/vistas/js/dashboardInventario.js
+++ b/vistas/js/dashboardInventario.js
@@ -1,0 +1,10 @@
+$(function(){
+  const base = window.BASE_URL || '';
+  $.getJSON(base + 'controlador/DashboardModuloController.php?op=inventario')
+    .done(data => {
+      $('#countArticulos').text(data.articulos || 0);
+      $('#countMovimientos').text(data.movimientos || 0);
+      $('#countMarcas').text(data.marcas || 0);
+      $('#countLineas').text(data.lineas || 0);
+    });
+});

--- a/vistas/js/dashboardSeguridad.js
+++ b/vistas/js/dashboardSeguridad.js
@@ -1,0 +1,10 @@
+$(function(){
+  const base = window.BASE_URL || '';
+  $.getJSON(base + 'controlador/DashboardModuloController.php?op=seguridad')
+    .done(data => {
+      $('#countUsuarios').text(data.usuarios || 0);
+      $('#countRoles').text(data.roles || 0);
+      $('#countPermisos').text(data.permisos || 0);
+      $('#countModulos').text(data.modulos || 0);
+    });
+});


### PR DESCRIPTION
## Summary
- extend `Dashboard` model with generic count helper
- implement `DashboardModuloController` for inventory and security stats
- add views and JS for new dashboards
- show new dashboards on navigation menu

## Testing
- `php -l modelos/Dashboard.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862d12853ec8327b039add5d07987c2