### PR TITLE
Add role-based dashboard

### DIFF
--- a/config/menu.php
+++ b/config/menu.php
@@ -7,7 +7,8 @@ $menu = [
         'items' => [
             ['label' => 'Principal',   'view' => 'dashboardSuperadmin'],
             ['label' => 'Inventario',  'view' => 'dashboardInventario'],
-            ['label' => 'Seguridad',   'view' => 'dashboardSeguridad']
+            ['label' => 'Seguridad',   'view' => 'dashboardSeguridad'],
+            ['label' => 'Roles',       'view' => 'dashboardRoles']
         ]
     ],
     'administracion' => [

--- a/controlador/DashboardRolController.php
+++ b/controlador/DashboardRolController.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+require_once '../modelos/Dashboard.php';
+$dash = new Dashboard();
+
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'usuarios':
+        echo json_encode($dash->usuariosPorRol());
+        break;
+    default:
+        http_response_code(400);
+        echo json_encode(['status'=>'error','msg'=>'Operación desconocida']);
+}

--- a/modelos/Dashboard.php
+++ b/modelos/Dashboard.php
@@ -33,4 +33,18 @@ class Dashboard
         }
         return $data;
     }
+
+    /**
+     * Cantidad de usuarios asignados a cada rol
+     */
+    public function usuariosPorRol(): array
+    {
+        $sql = "SELECT r.nombre AS rol, COUNT(u.id) AS total
+                  FROM rol r
+             LEFT JOIN usuario_rol ur ON ur.rol_id=r.id
+             LEFT JOIN usuario u ON u.id=ur.usuario_id
+              GROUP BY r.id
+              ORDER BY r.nombre";
+        return ejecutarConsultaArray($sql) ?: [];
+    }
 }

--- a/vistas/dashboardRoles.php
+++ b/vistas/dashboardRoles.php
@@ -1,0 +1,23 @@
+<?php
+$pageTitle = 'Dashboard Roles';
+require 'layout/header.php';
+require 'layout/navbar.php';
+require 'layout/sidebar.php';
+?>
+<div class="container-fluid pt-4">
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <div id="chartUsuariosRol" style="height:350px;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php require 'layout/footer.php'; ?>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+</script>
+<script src="<?= APP_URL ?>app/template/cork/plugins/apex/apexcharts.min.js"></script>
+<script src="<?= APP_URL ?>vistas/js/dashboardRoles.js"></script>

--- a/vistas/js/dashboardRoles.js
+++ b/vistas/js/dashboardRoles.js
@@ -1,0 +1,15 @@
+$(function(){
+  const base = window.BASE_URL || '';
+  $.getJSON(base + 'controlador/DashboardRolController.php?op=usuarios')
+    .done(data => {
+      const labels = data.map(d => d.rol);
+      const values = data.map(d => parseInt(d.total));
+      const options = {
+        chart: { type: 'bar', height: 350 },
+        series: [{ name: 'Usuarios', data: values }],
+        xaxis: { categories: labels }
+      };
+      const chart = new ApexCharts(document.querySelector('#chartUsuariosRol'), options);
+      chart.render();
+    });
+});


### PR DESCRIPTION
## Summary
- extend `Dashboard` model with `usuariosPorRol`
- add `DashboardRolController` to serve role metrics
- create `dashboardRoles` view and JS for ApexCharts graph
- show new menu option for role dashboard

## Testing
- `php -l modelos/Dashboard.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d47eca4083278d18bcbb71dce0b3