### PR TITLE
Add inventory dashboard chart

### DIFF
--- a/controlador/DashboardModuloController.php
+++ b/controlador/DashboardModuloController.php
@@ -28,6 +28,10 @@ switch ($op) {
         echo json_encode($dash->resumenPorTablas($tablas));
         break;
 
+    case 'articulos_marca':
+        echo json_encode($dash->articulosPorMarca());
+        break;
+
     default:
         http_response_code(400);
         echo json_encode(['status' => 'error', 'msg' => 'Operación desconocida']);

--- a/modelos/Dashboard.php
+++ b/modelos/Dashboard.php
@@ -47,4 +47,18 @@ class Dashboard
               ORDER BY r.nombre";
         return ejecutarConsultaArray($sql) ?: [];
     }
+
+    /**
+     * Cantidad de artículos registrados por marca
+     */
+    public function articulosPorMarca(): array
+    {
+        $sql = "SELECT IFNULL(m.nombre, 'Sin Marca') AS marca, COUNT(a.id) AS total
+                  FROM articulo a
+             LEFT JOIN marca m ON a.marca_id = m.id
+              GROUP BY m.nombre
+              ORDER BY marca";
+
+        return ejecutarConsultaArray($sql) ?: [];
+    }
 }

--- a/vistas/dashboardInventario.php
+++ b/vistas/dashboardInventario.php
@@ -39,9 +39,19 @@ require 'layout/sidebar.php';
       </div>
     </div>
   </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <div id="chartArticulosMarca" style="height:350px;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 <?php require 'layout/footer.php'; ?>
 <script>
   window.BASE_URL = '<?= APP_URL ?>';
 </script>
+<script src="<?= APP_URL ?>app/template/cork/plugins/apex/apexcharts.min.js"></script>
 <script src="<?= APP_URL ?>vistas/js/dashboardInventario.js"></script>

--- a/vistas/js/dashboardInventario.js
+++ b/vistas/js/dashboardInventario.js
@@ -7,4 +7,18 @@ $(function(){
       $('#countMarcas').text(data.marcas || 0);
       $('#countLineas').text(data.lineas || 0);
     });
+
+  // Gráfico de artículos por marca
+  $.getJSON(base + 'controlador/DashboardModuloController.php?op=articulos_marca')
+    .done(datos => {
+      const etiquetas = datos.map(d => d.marca);
+      const valores = datos.map(d => parseInt(d.total));
+      const opciones = {
+        chart: { type: 'donut', height: 350 },
+        series: valores,
+        labels: etiquetas
+      };
+      const grafico = new ApexCharts(document.querySelector('#chartArticulosMarca'), opciones);
+      grafico.render();
+    });
 });


### PR DESCRIPTION
## Summary
- add `articulosPorMarca` model method
- expose new controller endpoint for inventory chart
- show donut chart of articles per brand in inventory dashboard
- load ApexCharts on that page

## Testing
- `php -l modelos/Dashboard.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68633c3bbe3c832794f5794ff897d315