### PR TITLE
Implementar módulo de reporte para superadmin

### DIFF
--- a/controlador/ReporteSistemaController.php
+++ b/controlador/ReporteSistemaController.php
@@ -1,0 +1,32 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+require_once __DIR__ . '/../modelos/ReporteSistema.php';
+$rep = new ReporteSistema();
+
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'estadisticas':
+        $mod = $_GET['mod']    ?? '';
+        $ini = $_GET['inicio'] ?? '';
+        $fin = $_GET['fin']    ?? '';
+        if ($mod === '' || $ini === '' || $fin === '') {
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'msg' => 'Par\u00e1metros incompletos']);
+            break;
+        }
+        $data = $rep->estadisticas($mod, $ini, $fin);
+        if ($data === false) {
+            logError('Error al obtener estad\u00edsticas de ' . $mod);
+            http_response_code(500);
+            echo json_encode(['status' => 'error']);
+            break;
+        }
+        echo json_encode(['data' => $data]);
+        break;
+    default:
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'msg' => 'Operaci\u00f3n desconocida']);
+}

--- a/modelos/ReporteSistema.php
+++ b/modelos/ReporteSistema.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class ReporteSistema
+{
+    private $map = [
+        'cliente'    => ['tabla' => 'cliente', 'columna' => 'fecha_registro'],
+        'proveedor'  => ['tabla' => 'proveedor', 'columna' => 'fecha_registro'],
+        'articulo'   => ['tabla' => 'articulo', 'columna' => 'created_at'],
+        'movimiento' => ['tabla' => 'almacen_movimiento', 'columna' => 'fecha'],
+        'usuario'    => ['tabla' => 'usuario', 'columna' => 'created_at'],
+    ];
+
+    /**
+     * Obtiene el conteo diario de registros para un módulo.
+     * @return array|false
+     */
+    public function estadisticas(string $modulo, string $inicio, string $fin)
+    {
+        if (!isset($this->map[$modulo])) {
+            return [];
+        }
+        $tabla = $this->map[$modulo]['tabla'];
+        $col   = $this->map[$modulo]['columna'];
+        $sql = "SELECT DATE($col) AS fecha, COUNT(*) AS total
+                  FROM $tabla
+                 WHERE $col BETWEEN ? AND ?
+              GROUP BY DATE($col)
+              ORDER BY DATE($col)";
+        return ejecutarConsultaArray($sql, ["$inicio 00:00:00", "$fin 23:59:59"]);
+    }
+}

--- a/vistas/js/reporteSistema.js
+++ b/vistas/js/reporteSistema.js
@@ -1,0 +1,30 @@
+$(function(){
+  const BASE = window.BASE_URL || '';
+  const API  = BASE + 'controlador/ReporteSistemaController.php';
+
+  const chart = new ApexCharts(document.querySelector('#chartReporte'), {
+    chart: { type: 'line', height: 300 },
+    series: [{ name: 'Registros', data: [] }],
+    xaxis: { categories: [] }
+  });
+  chart.render();
+
+  $('#btnFiltrar').on('click', function(){
+    const mod = $('#selModulo').val();
+    const inicio = $('#fInicio').val();
+    const fin = $('#fFin').val();
+    if(!mod || !inicio || !fin){
+      alert('Completa el módulo y rango de fechas');
+      return;
+    }
+    $.getJSON(API, { op:'estadisticas', mod:mod, inicio:inicio, fin:fin })
+      .done(function(resp){
+        const fechas = resp.data.map(r => r.fecha);
+        const valores = resp.data.map(r => parseInt(r.total,10) || 0);
+        chart.updateOptions({ xaxis: { categories: fechas } });
+        chart.updateSeries([{ name:'Registros', data: valores }]);
+      });
+  });
+
+  $('#btnFiltrar').click();
+});

--- a/vistas/layout/sidebar.php
+++ b/vistas/layout/sidebar.php
@@ -45,6 +45,12 @@ $menu = [
             ['label' => 'Módulos', 'view' => 'modulo']
         ]
     ],
+    'reportes' => [
+        'icon' => 'fas fa-chart-bar',
+        'items' => [
+            ['label' => 'Reporte Sistema', 'view' => 'reporteSistema']
+        ]
+    ],
     'logout' => [
         'icon' => 'fas fa-sign-out-alt',
         'url'  => APP_URL . 'logout'

--- a/vistas/reporteSistema.php
+++ b/vistas/reporteSistema.php
@@ -1,0 +1,54 @@
+<?php $pageTitle = 'Reporte del Sistema'; ?>
+<?php require 'layout/header.php'; ?>
+<?php require 'layout/navbar.php'; ?>
+<?php require 'layout/sidebar.php'; ?>
+
+<div class="container-fluid pt-4">
+    <div class="row page-titles">
+        <div class="col-md-5">
+            <h3 class="text-themecolor"><?= $pageTitle ?></h3>
+        </div>
+        <div class="col-md-7">
+            <ol class="breadcrumb float-right">
+                <li class="breadcrumb-item"><a href="<?= APP_URL ?>">Inicio</a></li>
+                <li class="breadcrumb-item active"><?= $pageTitle ?></li>
+            </ol>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <div class="row mb-3 align-items-end">
+                <div class="col-md-3">
+                    <label>Módulo</label>
+                    <select id="selModulo" class="form-select">
+                        <option value="cliente">Clientes</option>
+                        <option value="proveedor">Proveedores</option>
+                        <option value="articulo">Artículos</option>
+                        <option value="movimiento">Movimientos</option>
+                        <option value="usuario">Usuarios</option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label>Fecha Inicio</label>
+                    <input type="date" id="fInicio" class="form-control" value="<?= date('Y-m-d') ?>">
+                </div>
+                <div class="col-md-3">
+                    <label>Fecha Fin</label>
+                    <input type="date" id="fFin" class="form-control" value="<?= date('Y-m-d') ?>">
+                </div>
+                <div class="col-md-3 text-md-end">
+                    <button id="btnFiltrar" class="btn btn-primary">Filtrar</button>
+                </div>
+            </div>
+            <div id="chartReporte" style="min-height:300px;"></div>
+        </div>
+    </div>
+</div>
+
+<?php require 'layout/footer.php'; ?>
+<script>
+    const BASE_URL = '<?= APP_URL ?>';
+</script>
+<script src="<?= APP_URL ?>app/template/cork/plugins/apex/apexcharts.min.js"></script>
+<script src="<?= APP_URL ?>vistas/js/reporteSistema.js"></script>


### PR DESCRIPTION
## Summary
- añadir modelo `ReporteSistema` para estadísticas por módulo
- crear controlador asociado `ReporteSistemaController`
- generar nueva vista `reporteSistema` con filtros por fecha y módulo
- agregar script JS para cargar datos y mostrar gráfico interactivo
- incluir enlace a Reporte Sistema en el menú lateral

## Testing
- `php -l modelos/ReporteSistema.php` *(fails: command not found)*
- `php -l controlador/ReporteSistemaController.php` *(fails: command not found)*
- `php -l vistas/reporteSistema.php` *(fails: command not found)*
- `php -l vistas/layout/sidebar.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633ccd564c83279658c86bdba516eb