### PR TITLE
Add basic work order module

### DIFF
--- a/controlador/OrdenTrabajoController.php
+++ b/controlador/OrdenTrabajoController.php
@@ -1,0 +1,124 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+require_once __DIR__ . '/../modelos/OrdenTrabajo.php';
+require_once __DIR__ . '/../modelos/OrdenTrabajoTarea.php';
+header('Content-Type: application/json; charset=utf-8');
+
+$ot = new OrdenTrabajo();
+$tt = new OrdenTrabajoTarea();
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'guardar':
+        $ok = $ot->insertar(
+            $_POST['proyecto_id'] ?? 0,
+            $_POST['codigo'] ?? '',
+            $_POST['descripcion'] ?? '',
+            $_POST['estado_id'] ?? null,
+            $_POST['fecha_inicio'] ?? null,
+            $_POST['fecha_fin'] ?? null
+        );
+        echo json_encode(['status' => $ok ? 'success' : 'error', 'msg' => $ok ? 'Orden registrada' : 'Error al registrar']);
+        break;
+
+    case 'editar':
+        $ok = $ot->editar(
+            $_POST['id'] ?? 0,
+            $_POST['proyecto_id'] ?? 0,
+            $_POST['codigo'] ?? '',
+            $_POST['descripcion'] ?? '',
+            $_POST['estado_id'] ?? null,
+            $_POST['fecha_inicio'] ?? null,
+            $_POST['fecha_fin'] ?? null
+        );
+        echo json_encode(['status' => $ok ? 'success' : 'error', 'msg' => $ok ? 'Orden actualizada' : 'Error al actualizar']);
+        break;
+
+    case 'desactivar':
+        $ok = $ot->desactivar($_POST['id'] ?? 0);
+        echo json_encode(['status' => $ok ? 'success' : 'error']);
+        break;
+
+    case 'activar':
+        $ok = $ot->activar($_POST['id'] ?? 0);
+        echo json_encode(['status' => $ok ? 'success' : 'error']);
+        break;
+
+    case 'mostrar':
+        echo json_encode($ot->mostrar($_POST['id'] ?? 0));
+        break;
+
+    case 'listar':
+        $rs   = $ot->listar();
+        $data = [];
+        while ($r = $rs->fetch_object()) {
+            $estado = $r->is_active
+                ? '<span class="badge badge-success">Activo</span>'
+                : '<span class="badge badge-danger">Inactivo</span>';
+            $botones = $r->is_active
+                ? '<button class="btn btn-sm btn-primary btn-edit" data-id="' . $r->id . '"><i class="fa fa-edit"></i></button> '
+                  . '<button class="btn btn-sm btn-danger btn-deactivate" data-id="' . $r->id . '"><i class="fa fa-trash"></i></button>'
+                : '<button class="btn btn-sm btn-success btn-activate" data-id="' . $r->id . '"><i class="fa fa-check"></i></button>';
+            $data[] = [
+                $r->id,
+                htmlspecialchars($r->proyecto),
+                htmlspecialchars($r->codigo),
+                $r->fecha_inicio,
+                $r->fecha_fin,
+                htmlspecialchars($r->estado ?? ''),
+                $r->created_at,
+                $r->updated_at,
+                $estado,
+                $botones
+            ];
+        }
+        echo json_encode(['data' => $data]);
+        break;
+
+    case 'selectProyecto':
+        header('Content-Type: text/html; charset=utf-8');
+        $rs = $ot->selectProyecto();
+        while ($r = $rs->fetch_object()) {
+            echo '<option value="' . $r->id . '">' . htmlspecialchars($r->nombre) . '</option>';
+        }
+        exit;
+
+    case 'selectEstado':
+        header('Content-Type: text/html; charset=utf-8');
+        $rs = $ot->selectEstado();
+        while ($r = $rs->fetch_object()) {
+            echo '<option value="' . $r->id . '">' . htmlspecialchars($r->descripcion) . '</option>';
+        }
+        exit;
+
+    case 'agregarTarea':
+        $ok = $tt->insertar(
+            $_POST['orden_trabajo_id'] ?? 0,
+            $_POST['descripcion'] ?? '',
+            $_POST['empleado_id'] ?? null,
+            $_POST['horas'] ?? 0,
+            $_POST['costo_hora'] ?? 0
+        );
+        echo json_encode(['status' => $ok ? 'success' : 'error', 'msg' => $ok ? 'Tarea registrada' : 'Error al registrar']);
+        break;
+
+    case 'listarTareas':
+        $rs   = $tt->listarPorOrden($_GET['orden_id'] ?? 0);
+        $data = [];
+        while ($r = $rs->fetch_object()) {
+            $data[] = [
+                $r->id,
+                htmlspecialchars($r->descripcion),
+                htmlspecialchars($r->empleado ?? ''),
+                $r->horas,
+                $r->costo_hora,
+                $r->costo_total
+            ];
+        }
+        echo json_encode(['data' => $data]);
+        break;
+
+    default:
+        echo json_encode(['data' => []]);
+        break;
+}

--- a/controlador/ProyectoController.php
+++ b/controlador/ProyectoController.php
@@ -1,0 +1,79 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+require_once __DIR__ . '/../modelos/Proyecto.php';
+header('Content-Type: application/json; charset=utf-8');
+
+$proy = new Proyecto();
+$op   = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'guardar':
+        $ok  = $proy->insertar(
+            $_POST['nombre'] ?? '',
+            $_POST['descripcion'] ?? '',
+            $_POST['fecha_inicio'] ?? null,
+            $_POST['fecha_fin'] ?? null
+        );
+        echo json_encode(['status' => $ok ? 'success' : 'error', 'msg' => $ok ? 'Proyecto registrado' : 'Error al registrar']);
+        break;
+
+    case 'editar':
+        $ok  = $proy->editar(
+            $_POST['id'] ?? 0,
+            $_POST['nombre'] ?? '',
+            $_POST['descripcion'] ?? '',
+            $_POST['fecha_inicio'] ?? null,
+            $_POST['fecha_fin'] ?? null
+        );
+        echo json_encode(['status' => $ok ? 'success' : 'error', 'msg' => $ok ? 'Proyecto actualizado' : 'Error al actualizar']);
+        break;
+
+    case 'desactivar':
+        $ok = $proy->desactivar($_POST['id'] ?? 0);
+        echo json_encode(['status' => $ok ? 'success' : 'error']);
+        break;
+
+    case 'activar':
+        $ok = $proy->activar($_POST['id'] ?? 0);
+        echo json_encode(['status' => $ok ? 'success' : 'error']);
+        break;
+
+    case 'mostrar':
+        echo json_encode($proy->mostrar($_POST['id'] ?? 0));
+        break;
+
+    case 'listar':
+        $rs   = $proy->listar();
+        $data = [];
+        while ($r = $rs->fetch_object()) {
+            $estado = $r->is_active
+                ? '<span class="badge badge-success">Activo</span>'
+                : '<span class="badge badge-danger">Inactivo</span>';
+            $botones = $r->is_active
+                ? '<button class="btn btn-sm btn-primary btn-edit" data-id="' . $r->id . '"><i class="fa fa-edit"></i></button> '
+                  . '<button class="btn btn-sm btn-danger btn-deactivate" data-id="' . $r->id . '"><i class="fa fa-trash"></i></button>'
+                : '<button class="btn btn-sm btn-success btn-activate" data-id="' . $r->id . '"><i class="fa fa-check"></i></button>';
+            $data[] = [
+                $r->id,
+                htmlspecialchars($r->nombre),
+                $r->created_at,
+                $r->updated_at,
+                $estado,
+                $botones
+            ];
+        }
+        echo json_encode(['data' => $data]);
+        break;
+
+    case 'select':
+        header('Content-Type: text/html; charset=utf-8');
+        $rs = $proy->select();
+        while ($r = $rs->fetch_object()) {
+            echo '<option value="' . $r->id . '">' . htmlspecialchars($r->nombre) . '</option>';
+        }
+        exit;
+
+    default:
+        echo json_encode(['data' => []]);
+        break;
+}

--- a/db.sql
+++ b/db.sql
@@ -653,6 +653,60 @@ CREATE TABLE `pedido_venta` (
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `proyecto`
+--
+
+CREATE TABLE `proyecto` (
+  `id` int(11) NOT NULL,
+  `nombre` varchar(150) NOT NULL,
+  `descripcion` text DEFAULT NULL,
+  `fecha_inicio` date DEFAULT NULL,
+  `fecha_fin` date DEFAULT NULL,
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
+  `created_at` datetime NOT NULL DEFAULT current_timestamp(),
+  `updated_at` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Estructura de tabla para la tabla `orden_trabajo`
+--
+
+CREATE TABLE `orden_trabajo` (
+  `id` int(11) NOT NULL,
+  `proyecto_id` int(11) NOT NULL,
+  `codigo` varchar(50) NOT NULL,
+  `descripcion` text DEFAULT NULL,
+  `estado_id` int(11) DEFAULT NULL,
+  `fecha_inicio` date DEFAULT NULL,
+  `fecha_fin` date DEFAULT NULL,
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
+  `created_at` datetime NOT NULL DEFAULT current_timestamp(),
+  `updated_at` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Estructura de tabla para la tabla `orden_trabajo_tarea`
+--
+
+CREATE TABLE `orden_trabajo_tarea` (
+  `id` int(11) NOT NULL,
+  `orden_trabajo_id` int(11) NOT NULL,
+  `descripcion` varchar(255) NOT NULL,
+  `empleado_id` int(11) DEFAULT NULL,
+  `horas` decimal(8,2) DEFAULT NULL,
+  `costo_hora` decimal(14,2) DEFAULT NULL,
+  `costo_total` decimal(14,2) DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT current_timestamp(),
+  `updated_at` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `atencion_cliente`
 --
 
@@ -982,6 +1036,29 @@ ALTER TABLE `pedido_venta`
   ADD KEY `estado_id` (`estado_id`);
 
 --
+-- Indices de la tabla `proyecto`
+--
+ALTER TABLE `proyecto`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- Indices de la tabla `orden_trabajo`
+--
+ALTER TABLE `orden_trabajo`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `codigo` (`codigo`),
+  ADD KEY `proyecto_id` (`proyecto_id`),
+  ADD KEY `estado_id` (`estado_id`);
+
+--
+-- Indices de la tabla `orden_trabajo_tarea`
+--
+ALTER TABLE `orden_trabajo_tarea`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `orden_trabajo_id` (`orden_trabajo_id`),
+  ADD KEY `empleado_id` (`empleado_id`);
+
+--
 -- Indices de la tabla `atencion_cliente`
 --
 ALTER TABLE `atencion_cliente`
@@ -1210,6 +1287,24 @@ ALTER TABLE `pedido_venta`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT de la tabla `proyecto`
+--
+ALTER TABLE `proyecto`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de la tabla `orden_trabajo`
+--
+ALTER TABLE `orden_trabajo`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de la tabla `orden_trabajo_tarea`
+--
+ALTER TABLE `orden_trabajo_tarea`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT de la tabla `atencion_cliente`
 --
 ALTER TABLE `atencion_cliente`
@@ -1311,6 +1406,20 @@ ALTER TABLE `cotizacion`
 ALTER TABLE `pedido_venta`
   ADD CONSTRAINT `pedido_venta_cliente_fk` FOREIGN KEY (`cliente_id`) REFERENCES `cliente` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `pedido_venta_estado_fk` FOREIGN KEY (`estado_id`) REFERENCES `estado_documento` (`id`) ON UPDATE CASCADE;
+
+--
+-- Filtros para la tabla `orden_trabajo`
+--
+ALTER TABLE `orden_trabajo`
+  ADD CONSTRAINT `orden_trabajo_proyecto_fk` FOREIGN KEY (`proyecto_id`) REFERENCES `proyecto` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `orden_trabajo_estado_fk` FOREIGN KEY (`estado_id`) REFERENCES `estado_orden_trabajo` (`id`) ON UPDATE CASCADE;
+
+--
+-- Filtros para la tabla `orden_trabajo_tarea`
+--
+ALTER TABLE `orden_trabajo_tarea`
+  ADD CONSTRAINT `ott_orden_fk` FOREIGN KEY (`orden_trabajo_id`) REFERENCES `orden_trabajo` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `ott_empleado_fk` FOREIGN KEY (`empleado_id`) REFERENCES `empleado` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
 
 --
 -- Filtros para la tabla `atencion_cliente`

--- a/modelos/OrdenTrabajo.php
+++ b/modelos/OrdenTrabajo.php
@@ -1,0 +1,96 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class OrdenTrabajo
+{
+    public function insertar($proyecto_id, $codigo, $descripcion, $estado_id, $fecha_inicio, $fecha_fin)
+    {
+        $sql = "INSERT INTO orden_trabajo
+                    (proyecto_id, codigo, descripcion, estado_id, fecha_inicio, fecha_fin, created_at, updated_at, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), 1)";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($proyecto_id),
+            limpiarCadena($codigo),
+            limpiarCadena($descripcion),
+            limpiarCadena($estado_id),
+            limpiarCadena($fecha_inicio),
+            limpiarCadena($fecha_fin)
+        ]);
+    }
+
+    public function editar($id, $proyecto_id, $codigo, $descripcion, $estado_id, $fecha_inicio, $fecha_fin)
+    {
+        $sql = "UPDATE orden_trabajo SET
+                    proyecto_id = ?,
+                    codigo = ?,
+                    descripcion = ?,
+                    estado_id = ?,
+                    fecha_inicio = ?,
+                    fecha_fin = ?,
+                    updated_at = NOW()
+                WHERE id = ?";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($proyecto_id),
+            limpiarCadena($codigo),
+            limpiarCadena($descripcion),
+            limpiarCadena($estado_id),
+            limpiarCadena($fecha_inicio),
+            limpiarCadena($fecha_fin),
+            limpiarCadena($id)
+        ]);
+    }
+
+    public function desactivar($id)
+    {
+        return ejecutarConsulta(
+            "UPDATE orden_trabajo SET is_active=0, updated_at=NOW() WHERE id=?",
+            [limpiarCadena($id)]
+        );
+    }
+
+    public function activar($id)
+    {
+        return ejecutarConsulta(
+            "UPDATE orden_trabajo SET is_active=1, updated_at=NOW() WHERE id=?",
+            [limpiarCadena($id)]
+        );
+    }
+
+    public function mostrar($id)
+    {
+        return ejecutarConsultaSimpleFila(
+            "SELECT * FROM orden_trabajo WHERE id=?",
+            [limpiarCadena($id)]
+        );
+    }
+
+    public function listar()
+    {
+        $sql = "SELECT ot.id,
+                       p.nombre AS proyecto,
+                       ot.codigo,
+                       ot.fecha_inicio,
+                       ot.fecha_fin,
+                       eot.descripcion AS estado,
+                       DATE_FORMAT(ot.created_at,'%Y-%m-%d %H:%i') AS created_at,
+                       DATE_FORMAT(ot.updated_at,'%Y-%m-%d %H:%i') AS updated_at,
+                       ot.is_active
+                  FROM orden_trabajo ot
+             LEFT JOIN proyecto p ON p.id = ot.proyecto_id
+             LEFT JOIN estado_orden_trabajo eot ON eot.id = ot.estado_id
+                 ORDER BY ot.id DESC";
+        return ejecutarConsulta($sql);
+    }
+
+    public function selectProyecto()
+    {
+        $sql = "SELECT id, nombre FROM proyecto WHERE is_active=1 ORDER BY nombre";
+        return ejecutarConsulta($sql);
+    }
+
+    public function selectEstado()
+    {
+        $sql = "SELECT id, descripcion FROM estado_orden_trabajo WHERE is_active=1 ORDER BY descripcion";
+        return ejecutarConsulta($sql);
+    }
+}

--- a/modelos/OrdenTrabajoTarea.php
+++ b/modelos/OrdenTrabajoTarea.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class OrdenTrabajoTarea
+{
+    public function insertar($orden_id, $descripcion, $empleado_id, $horas, $costo_hora)
+    {
+        $costo_total = (float)$horas * (float)$costo_hora;
+        $sql = "INSERT INTO orden_trabajo_tarea
+                    (orden_trabajo_id, descripcion, empleado_id, horas, costo_hora, costo_total, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($orden_id),
+            limpiarCadena($descripcion),
+            limpiarCadena($empleado_id),
+            limpiarCadena($horas),
+            limpiarCadena($costo_hora),
+            $costo_total
+        ]);
+    }
+
+    public function listarPorOrden($orden_id)
+    {
+        $sql = "SELECT ott.id,
+                       ott.descripcion,
+                       CONCAT(e.nombre,' ',e.apellido) AS empleado,
+                       ott.horas,
+                       ott.costo_hora,
+                       ott.costo_total
+                  FROM orden_trabajo_tarea ott
+             LEFT JOIN empleado e ON e.id = ott.empleado_id
+                 WHERE ott.orden_trabajo_id = ?";
+        return ejecutarConsulta($sql, [limpiarCadena($orden_id)]);
+    }
+
+    public function costoPorProyecto($proyecto_id)
+    {
+        $sql = "SELECT SUM(ott.costo_total) AS total
+                  FROM orden_trabajo_tarea ott
+                  JOIN orden_trabajo ot ON ot.id = ott.orden_trabajo_id
+                 WHERE ot.proyecto_id = ?";
+        return ejecutarConsultaSimpleFila($sql, [limpiarCadena($proyecto_id)]);
+    }
+}

--- a/modelos/Proyecto.php
+++ b/modelos/Proyecto.php
@@ -1,0 +1,72 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class Proyecto
+{
+    public function insertar($nombre, $descripcion, $fecha_inicio, $fecha_fin)
+    {
+        $sql = "INSERT INTO proyecto
+                    (nombre, descripcion, fecha_inicio, fecha_fin, created_at, updated_at, is_active)
+                VALUES (?, ?, ?, ?, NOW(), NOW(), 1)";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($nombre),
+            limpiarCadena($descripcion),
+            limpiarCadena($fecha_inicio),
+            limpiarCadena($fecha_fin)
+        ]);
+    }
+
+    public function editar($id, $nombre, $descripcion, $fecha_inicio, $fecha_fin)
+    {
+        $sql = "UPDATE proyecto SET
+                    nombre = ?,
+                    descripcion = ?,
+                    fecha_inicio = ?,
+                    fecha_fin = ?,
+                    updated_at = NOW()
+                WHERE id = ?";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($nombre),
+            limpiarCadena($descripcion),
+            limpiarCadena($fecha_inicio),
+            limpiarCadena($fecha_fin),
+            limpiarCadena($id)
+        ]);
+    }
+
+    public function desactivar($id)
+    {
+        $sql = "UPDATE proyecto SET is_active=0, updated_at=NOW() WHERE id = ?";
+        return ejecutarConsulta($sql, [limpiarCadena($id)]);
+    }
+
+    public function activar($id)
+    {
+        $sql = "UPDATE proyecto SET is_active=1, updated_at=NOW() WHERE id = ?";
+        return ejecutarConsulta($sql, [limpiarCadena($id)]);
+    }
+
+    public function mostrar($id)
+    {
+        $sql = "SELECT * FROM proyecto WHERE id = ?";
+        return ejecutarConsultaSimpleFila($sql, [limpiarCadena($id)]);
+    }
+
+    public function listar()
+    {
+        $sql = "SELECT id,
+                       nombre,
+                       DATE_FORMAT(created_at,'%Y-%m-%d %H:%i') AS created_at,
+                       DATE_FORMAT(updated_at,'%Y-%m-%d %H:%i') AS updated_at,
+                       is_active
+                  FROM proyecto
+                 ORDER BY nombre";
+        return ejecutarConsulta($sql);
+    }
+
+    public function select()
+    {
+        $sql = "SELECT id, nombre FROM proyecto WHERE is_active = 1 ORDER BY nombre";
+        return ejecutarConsulta($sql);
+    }
+}

--- a/vistas/js/ordenTrabajo.js
+++ b/vistas/js/ordenTrabajo.js
@@ -1,0 +1,17 @@
+$(function () {
+  initCrud({
+    controller: 'OrdenTrabajoController.php',
+    tableId: 'tblOrdenTrabajo',
+    modalId: 'modalOrdenTrabajo',
+    formId: 'formOrdenTrabajo'
+  });
+
+  $('#modalOrdenTrabajo').on('show.bs.modal', function () {
+    $.get(window.BASE_URL + 'controlador/OrdenTrabajoController.php?op=selectProyecto', function (r) {
+      $('select[name=proyecto_id]').html(r);
+    });
+    $.get(window.BASE_URL + 'controlador/OrdenTrabajoController.php?op=selectEstado', function (r) {
+      $('select[name=estado_id]').html(r);
+    });
+  });
+});

--- a/vistas/js/proyecto.js
+++ b/vistas/js/proyecto.js
@@ -1,0 +1,8 @@
+$(function () {
+  initCrud({
+    controller: 'ProyectoController.php',
+    tableId: 'tblProyecto',
+    modalId: 'modalProyecto',
+    formId: 'formProyecto'
+  });
+});

--- a/vistas/ordenTrabajo.php
+++ b/vistas/ordenTrabajo.php
@@ -1,0 +1,56 @@
+<?php $pageTitle = 'Orden Trabajo'; ?>
+<?php require 'layout/header.php'; ?>
+<?php require 'layout/navbar.php'; ?>
+<?php require 'layout/sidebar.php'; ?>
+  <div class="container-fluid pt-4">
+    <div class="row page-titles">
+      <div class="col-md-5 align-self-center">
+        <h3 class="text-themecolor"><?= $pageTitle ?></h3>
+      </div>
+      <div class="col-md-7 align-self-center">
+        <ol class="breadcrumb float-right">
+          <li class="breadcrumb-item"><a href="<?= APP_URL ?>">Inicio</a></li>
+          <li class="breadcrumb-item active"><?= $pageTitle ?></li>
+        </ol>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body">
+        <button id="btnNuevo" class="btn btn-success mb-3">
+          <i class="fa fa-plus"></i> Nuevo
+        </button>
+        <div class="table-responsive">
+          <table id="tblOrdenTrabajo" class="table color-table inverse-table" style="width:100%">
+            <thead id="tblHead" style="background-color: #2A3E52; color: white;"></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div class="modal fade" id="modalOrdenTrabajo" tabindex="-1">
+      <div class="modal-dialog">
+        <form id="formOrdenTrabajo" class="modal-content">
+          <div class="modal-header bg-primary text-white">
+            <h5 class="modal-title">Nueva Orden Trabajo</h5>
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+          </div>
+          <div class="modal-body" id="formFields"></div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-light">Guardar</button>
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+<?php require "layout/footer.php"; ?>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'OrdenTrabajoController.php',
+    tableId: 'tblOrdenTrabajo',
+    modalId: 'modalOrdenTrabajo',
+    formId: 'formOrdenTrabajo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/proyecto.php
+++ b/vistas/proyecto.php
@@ -1,0 +1,56 @@
+<?php $pageTitle = 'Proyecto'; ?>
+<?php require 'layout/header.php'; ?>
+<?php require 'layout/navbar.php'; ?>
+<?php require 'layout/sidebar.php'; ?>
+  <div class="container-fluid pt-4">
+    <div class="row page-titles">
+      <div class="col-md-5 align-self-center">
+        <h3 class="text-themecolor"><?= $pageTitle ?></h3>
+      </div>
+      <div class="col-md-7 align-self-center">
+        <ol class="breadcrumb float-right">
+          <li class="breadcrumb-item"><a href="<?= APP_URL ?>">Inicio</a></li>
+          <li class="breadcrumb-item active"><?= $pageTitle ?></li>
+        </ol>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body">
+        <button id="btnNuevo" class="btn btn-success mb-3">
+          <i class="fa fa-plus"></i> Nuevo
+        </button>
+        <div class="table-responsive">
+          <table id="tblProyecto" class="table color-table inverse-table" style="width:100%">
+            <thead id="tblHead" style="background-color: #2A3E52; color: white;"></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div class="modal fade" id="modalProyecto" tabindex="-1">
+      <div class="modal-dialog">
+        <form id="formProyecto" class="modal-content">
+          <div class="modal-header bg-primary text-white">
+            <h5 class="modal-title">Nuevo Proyecto</h5>
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+          </div>
+          <div class="modal-body" id="formFields"></div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-light">Guardar</button>
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+<?php require "layout/footer.php"; ?>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ProyectoController.php',
+    tableId: 'tblProyecto',
+    modalId: 'modalProyecto',
+    formId: 'formProyecto'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>


### PR DESCRIPTION
## Summary
- implement new database tables for projects and work orders
- add models for `Proyecto`, `OrdenTrabajo` and `OrdenTrabajoTarea`
- create controllers for projects and work orders
- generate simple views and JS helpers

## Testing
- `php -l controlador/ProyectoController.php` *(fails: php not found)*
- `php -l controlador/OrdenTrabajoController.php` *(fails: php not found)*
- `php -l modelos/Proyecto.php` *(fails: php not found)*
- `php -l modelos/OrdenTrabajo.php` *(fails: php not found)*
- `php -l modelos/OrdenTrabajoTarea.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686361a7971083279108e1c8f297d60d