### PR TITLE
Fix controller routing and avoid undefined parameter

### DIFF
--- a/controlador/AlmacenMovimientoController.php
+++ b/controlador/AlmacenMovimientoController.php
@@ -7,7 +7,7 @@ header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/../modelos/AlmacenMovimiento.php';
 
 $alm = new AlmacenMovimiento();
-$op = $_REQUEST['op'];
+$op = $_REQUEST['op'] ?? '';
 
 switch ($op) {
   case 'listar':
@@ -107,5 +107,10 @@ switch ($op) {
     $rows = [];
     while ($row = $rs->fetch_assoc()) $rows[] = $row;
     echo json_encode(['data' => $rows]);
+    break;
+
+  default:
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'msg' => 'Operación inválida']);
     break;
 }

--- a/index.php
+++ b/index.php
@@ -46,6 +46,11 @@ $controllerPath = 'controlador/' . $controllerName . '.php';
 
 // Verificar si el archivo del controlador existe
 if (file_exists($controllerPath)) {
+    // Ajustar "op" para controladores de tipo script
+    if (!isset($_REQUEST['op']) && $method !== 'index') {
+        $_GET['op'] = $_REQUEST['op'] = $method;
+    }
+
     require_once $controllerPath;
 
     // Verificar si la clase del controlador existe
@@ -62,9 +67,7 @@ if (file_exists($controllerPath)) {
             echo 'Error 404: Método no encontrado';
         }
     } else {
-        // Clase del controlador no encontrada
-        logError('Controlador no encontrado: ' . $controllerName);
-        echo 'Error 404: Controlador no encontrado';
+        // Controlador de tipo script ya ejecutado al incluir el archivo
     }
 } else {
     // Archivo del controlador no encontrado


### PR DESCRIPTION
## Summary
- fix `$op` undefined index in `AlmacenMovimientoController`
- add default case for invalid operations
- allow script style controllers in `index.php`

## Testing
- `php -l controlador/AlmacenMovimientoController.php` *(fails: command not found)*
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863672b59e4832791af299d96dec6f6