### PR TITLE
Fix base URL in almacen view

### DIFF
--- a/vistas/almacenMovimiento.php
+++ b/vistas/almacenMovimiento.php
@@ -231,7 +231,8 @@ require 'layout/sidebar.php';
 
   <?php require 'layout/footer.php'; ?>
 
+  <!-- Inyectar la URL base antes de cargar el script -->
   <script>
-    const BASE_URL = '<?= APP_URL ?>';
+    window.BASE_URL = '<?= APP_URL ?>';
   </script>
   <script src="<?= APP_URL ?>vistas/js/almacenMovimiento.js"></script>


### PR DESCRIPTION
## Summary
- expose `window.BASE_URL` in `almacenMovimiento.php` so JS endpoints work

## Testing
- `php` was not available so `php -l` could not be run

------
https://chatgpt.com/codex/tasks/task_e_68673c00cbc48327aaf14e361145dfdf