### PR TITLE
Corrige redirección por defecto y uso de APP_URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,8 +13,13 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 require_once 'config/global.php';
 require_once 'config/Utilidades.php';
 
-// Obtener la URL desde el parámetro 'url' o establecer 'home' por defecto
-$url = isset($_GET['url']) ? $_GET['url'] : 'home';
+// Obtener la URL desde el parámetro 'url'
+// Si no viene especificada redirigimos al inicio de sesión
+$url = $_GET['url'] ?? '';
+if ($url === '') {
+    header('Location: ' . APP_URL . 'login');
+    exit();
+}
 
 // Separar la URL en segmentos
 $url = explode('/', $url);

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
 session_destroy();
-header('Location: ' . '/cork/login');
+require_once __DIR__ . '/config/global.php';
+header('Location: ' . APP_URL . 'login');
 exit();


### PR DESCRIPTION
## Summary
- ajusta `index.php` para redirigir al login cuando no se indica ruta
- usa `APP_URL` en `logout.php`

## Testing
- `php -l index.php` *(fails: command not found)*
- `php -l logout.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675deb1d408327806f613baa1b1b89