### PR TITLE
Fix proveedor module with full CRUD

### DIFF
--- a/controlador/ProveedorController.php
+++ b/controlador/ProveedorController.php
@@ -22,7 +22,9 @@ $cargo_contacto       = isset($_POST['cargo_contacto'])     ? limpiarCadena($_PO
 $telefono_contacto    = isset($_POST['telefono_contacto'])  ? limpiarCadena($_POST['telefono_contacto'])  : '';
 $email_contacto       = isset($_POST['email_contacto'])     ? limpiarCadena($_POST['email_contacto'])     : '';
 
-switch ($_GET['op']) {
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
     case 'guardar':
         $rspta = $prov->insertar(
             $ruc, $razon_social, $categoria_id,
@@ -48,6 +50,22 @@ switch ($_GET['op']) {
         echo json_encode(['status' => $rspta ? 'success' : 'error', 'msg' => $rspta ? 'Proveedor actualizado correctamente' : 'Error al actualizar proveedor']);
         break;
 
+    case 'desactivar':
+        $rspta = $prov->desactivar($id);
+        echo json_encode([
+            'status' => $rspta ? 'success' : 'error',
+            'msg'    => $rspta ? 'Proveedor desactivado' : 'Error al desactivar proveedor'
+        ]);
+        break;
+
+    case 'activar':
+        $rspta = $prov->activar($id);
+        echo json_encode([
+            'status' => $rspta ? 'success' : 'error',
+            'msg'    => $rspta ? 'Proveedor activado' : 'Error al activar proveedor'
+        ]);
+        break;
+
     case 'mostrar':
         $rspta = $prov->mostrar($id);
         echo json_encode($rspta);
@@ -57,15 +75,21 @@ switch ($_GET['op']) {
         $rspta = $prov->listar();
         $data  = [];
         while ($reg = $rspta->fetch_object()) {
+            $estado = $reg->estado
+                ? '<span class="badge badge-success">Activo</span>'
+                : '<span class="badge badge-danger">Inactivo</span>';
+            $botones = $reg->estado
+                ? '<button class="btn btn-sm btn-primary btn-edit" data-id="' . $reg->id . '"><i class="fa fa-edit"></i></button> '
+                  . '<button class="btn btn-sm btn-danger btn-deactivate" data-id="' . $reg->id . '"><i class="fa fa-trash"></i></button>'
+                : '<button class="btn btn-sm btn-success btn-activate" data-id="' . $reg->id . '"><i class="fa fa-check"></i></button>';
             $data[] = [
                 $reg->id,
                 htmlspecialchars($reg->ruc),
                 htmlspecialchars($reg->razon_social),
                 htmlspecialchars($reg->email),
                 htmlspecialchars($reg->telefono_movil),
-                $reg->estado
-                    ? '<span class="badge badge-success">Activo</span>'
-                    : '<span class="badge badge-danger">Inactivo</span>'
+                $estado,
+                $botones
             ];
         }
         echo json_encode(["data" => $data]);
@@ -76,5 +100,9 @@ switch ($_GET['op']) {
         while ($reg = $rspta->fetch_object()) {
             echo "<option value=\"{$reg->id}\">" . htmlspecialchars($reg->razon_social) . "</option>";
         }
+        break;
+
+    default:
+        echo json_encode(['status' => 'error', 'msg' => 'Operación no válida']);
         break;
 }

--- a/vistas/js/proveedor.js
+++ b/vistas/js/proveedor.js
@@ -1,8 +1,98 @@
-$(function () {
-  initCrud({
-    controller: 'ProveedorController.php',
-    tableId: 'tblProveedor',
-    modalId: 'modalProveedor',
-    formId: 'formProveedor'
+(function ($) {
+  'use strict';
+  const table = $('#tblProveedor').DataTable({
+    ajax: {
+      url: BASE_URL + 'controlador/ProveedorController.php',
+      type: 'GET',
+      data: { op: 'listar' },
+      dataSrc: 'data'
+    },
+    columns: [
+      { data: 0 },{ data: 1 },{ data: 2 },{ data: 3 },{ data: 4 },{ data: 5 },{ data: 6 }
+    ],
+    language: { loadingRecords: 'Cargando...', zeroRecords: 'No hay proveedores', paginate: { previous: '‹', next: '›' } },
+    responsive: true,
+    autoWidth: false
   });
-});
+
+  function fetchData(op, data = {}, method = 'POST', dt = 'json') {
+    return $.ajax({
+      url: BASE_URL + 'controlador/ProveedorController.php?op=' + op,
+      method, data, dataType: dt
+    });
+  }
+
+  function loadCategories(sel = '') {
+    return $.get(BASE_URL + 'controlador/CategoriaProveedorController.php?op=select')
+      .done(html => {
+        $('select[name=categoria_id]').html(html).val(sel);
+      });
+  }
+
+  let ubigeo = null;
+  fetch(BASE_URL + 'data/ubigeo_peru.json')
+    .then(r => r.json())
+    .then(data => {
+      ubigeo = data;
+      const deps = Object.keys(data).sort();
+      deps.forEach(d => $('#lista-departamentos').append(`<option>${d}</option>`));
+    });
+
+  $('input[name=departamento]').on('input', function () {
+    const d = this.value;
+    const provs = ubigeo && ubigeo[d] ? Object.keys(ubigeo[d]).sort() : [];
+    $('#lista-provincias').empty();
+    provs.forEach(p => $('#lista-provincias').append(`<option>${p}</option>`));
+    $('#lista-distritos').empty();
+    $('input[name=distrito]').val('');
+  });
+
+  $('input[name=provincia]').on('input', function () {
+    const d = $('input[name=departamento]').val();
+    const p = this.value;
+    const dist = ubigeo && ubigeo[d] && ubigeo[d][p] ? ubigeo[d][p] : [];
+    $('#lista-distritos').empty();
+    dist.sort().forEach(x => $('#lista-distritos').append(`<option>${x}</option>`));
+  });
+
+  function openModal(data = {}) {
+    const form = $('#formProveedor')[0];
+    form.reset();
+    $(form).removeClass('was-validated');
+    if (data.id) Object.entries(data).forEach(([k, v]) => $(form).find(`[name="${k}"]`).val(v));
+    loadCategories(data.categoria_id || '').always(() => {
+      $('#modalProveedor .modal-title').text(data.id ? 'Editar Proveedor' : 'Nuevo Proveedor');
+      $('#modalProveedor').modal('show');
+    });
+  }
+
+  $('#btnNuevo').click(() => openModal());
+
+  $('#tblProveedor').on('click', '.btn-edit', function () {
+    fetchData('mostrar', { id: $(this).data('id') }).done(openModal);
+  });
+
+  $('#tblProveedor').on('click', '.btn-deactivate', function () {
+    const id = $(this).data('id');
+    Swal.fire({ title: '¿Desactivar proveedor?', icon: 'warning', showCancelButton: true, confirmButtonText: 'Sí' })
+      .then(r => { if (r.isConfirmed) fetchData('desactivar', { id }).done(x => { Swal.fire('', x.msg, x.status); table.ajax.reload(null, false); }); });
+  });
+
+  $('#tblProveedor').on('click', '.btn-activate', function () {
+    const id = $(this).data('id');
+    Swal.fire({ title: '¿Activar proveedor?', icon: 'question', showCancelButton: true, confirmButtonText: 'Sí' })
+      .then(r => { if (r.isConfirmed) fetchData('activar', { id }).done(x => { Swal.fire('', x.msg, x.status); table.ajax.reload(null, false); }); });
+  });
+
+  $('#formProveedor').on('submit', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const form = this;
+    if (!form.checkValidity()) { $(form).addClass('was-validated'); return; }
+    const op = $('[name=id]').val() ? 'editar' : 'guardar';
+    fetchData(op, $(form).serialize()).done(resp => {
+      Swal.fire(resp.status === 'success' ? 'Éxito' : 'Error', resp.msg, resp.status);
+      if (resp.status === 'success') { $('#modalProveedor').modal('hide'); table.ajax.reload(null, false); }
+    });
+  });
+})(jQuery);

--- a/vistas/proveedor.php
+++ b/vistas/proveedor.php
@@ -21,7 +21,17 @@
         </button>
         <div class="table-responsive">
           <table id="tblProveedor" class="table color-table inverse-table" style="width:100%">
-            <thead id="tblHead" style="background-color: #2A3E52; color: white;"></thead>
+            <thead style="background-color: #2A3E52; color: white;">
+              <tr>
+                <th width="5%">ID</th>
+                <th width="10%">RUC</th>
+                <th width="25%">Razón Social</th>
+                <th width="20%">Email</th>
+                <th width="15%">Teléfono</th>
+                <th width="10%">Estado</th>
+                <th width="15%">Opciones</th>
+              </tr>
+            </thead>
             <tbody></tbody>
           </table>
         </div>
@@ -29,12 +39,92 @@
     </div>
     <div class="modal fade" id="modalProveedor" tabindex="-1">
       <div class="modal-dialog">
-        <form id="formProveedor" class="modal-content">
+        <form id="formProveedor" class="modal-content needs-validation" novalidate>
           <div class="modal-header bg-primary text-white">
             <h5 class="modal-title">Nuevo Proveedor</h5>
             <button type="button" class="close" data-dismiss="modal">&times;</button>
           </div>
-          <div class="modal-body" id="formFields"></div>
+          <div class="modal-body">
+            <input type="hidden" name="id">
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label>RUC <span class="text-danger">*</span></label>
+                <input name="ruc" class="form-control" required maxlength="11" pattern="\d{11}">
+                <div class="invalid-feedback">RUC inválido.</div>
+              </div>
+              <div class="form-group col-md-6">
+                <label>Razón Social <span class="text-danger">*</span></label>
+                <input name="razon_social" class="form-control" required>
+                <div class="invalid-feedback">Complete la razón social.</div>
+              </div>
+            </div>
+            <div class="form-group">
+              <label>Categoría</label>
+              <select name="categoria_id" class="form-control"></select>
+            </div>
+            <div class="form-group">
+              <label>Dirección</label>
+              <input name="direccion" class="form-control">
+            </div>
+            <div class="form-row">
+              <div class="form-group col-md-4">
+                <label>Departamento</label>
+                <input name="departamento" class="form-control" list="lista-departamentos">
+                <datalist id="lista-departamentos"></datalist>
+              </div>
+              <div class="form-group col-md-4">
+                <label>Provincia</label>
+                <input name="provincia" class="form-control" list="lista-provincias">
+                <datalist id="lista-provincias"></datalist>
+              </div>
+              <div class="form-group col-md-4">
+                <label>Distrito</label>
+                <input name="distrito" class="form-control" list="lista-distritos">
+                <datalist id="lista-distritos"></datalist>
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label>Teléfono Fijo</label>
+                <input name="telefono_fijo" class="form-control">
+              </div>
+              <div class="form-group col-md-6">
+                <label>Teléfono Móvil</label>
+                <input name="telefono_movil" class="form-control">
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label>Email</label>
+                <input name="email" type="email" class="form-control">
+              </div>
+              <div class="form-group col-md-6">
+                <label>Web</label>
+                <input name="web" type="url" class="form-control">
+              </div>
+            </div>
+            <hr>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label>Responsable</label>
+                <input name="contacto_responsable" class="form-control">
+              </div>
+              <div class="form-group col-md-6">
+                <label>Cargo</label>
+                <input name="cargo_contacto" class="form-control">
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label>Teléfono Contacto</label>
+                <input name="telefono_contacto" class="form-control">
+              </div>
+              <div class="form-group col-md-6">
+                <label>Email Contacto</label>
+                <input name="email_contacto" type="email" class="form-control">
+              </div>
+            </div>
+          </div>
           <div class="modal-footer">
             <button type="submit" class="btn btn-light">Guardar</button>
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
@@ -44,13 +134,5 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>
-  window.BASE_URL = '<?= APP_URL ?>';
-  window.CRUD_CONFIG = {
-    controller: 'ProveedorController.php',
-    tableId: 'tblProveedor',
-    modalId: 'modalProveedor',
-    formId: 'formProveedor'
-  };
-</script>
-<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>
+<script>const BASE_URL = '<?= APP_URL ?>';</script>
+<script src="<?= APP_URL ?>vistas/js/proveedor.js"></script>


### PR DESCRIPTION
## Summary
- finish CRUD for suppliers: add activate/deactivate in controller
- show actions in supplier list
- redesign supplier view with full form
- write custom JS logic for supplier operations

## Testing
- `php -l controlador/ProveedorController.php` *(fails: command not found)*
- `php -l vistas/proveedor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867cc163f0c83278e333d14adf8ef54