### PR TITLE
Mejoras front-end del módulo de Artículos

### DIFF
--- a/vistas/articulos.php
+++ b/vistas/articulos.php
@@ -158,7 +158,7 @@
             <div class="form-group">
               <label for="imagen">Imagen</label>
               <div class="custom-file">
-                <input type="file" name="imagen" id="imagen" class="custom-file-input">
+                <input type="file" name="imagen" id="imagen" class="custom-file-input" accept="image/*">
                 <label class="custom-file-label" for="imagen">Selecciona archivo…</label>
               </div>
               <img id="imgPreview" src="#" class="img-thumbnail mt-2" style="max-height:120px; display:none;">


### PR DESCRIPTION
## Summary
- permitir solo imágenes en el selector de archivo
- cargar selects en paralelo y añadir clases en DataTable
- mostrar vista previa de la imagen cargada

## Testing
- `php -l vistas/articulos.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ea937cd083279b86dd2005524d96