### PR TITLE
Optimize articulos view and script

### DIFF
--- a/vistas/articulos.php
+++ b/vistas/articulos.php
@@ -187,4 +187,4 @@
 <script>
   window.BASE_URL = '<?= APP_URL ?>';
 </script>
-<script src="<?= APP_URL ?>vistas/js/articulos.js"></script>
+<script src="<?= APP_URL ?>vistas/js/articulos.js" defer></script>


### PR DESCRIPTION
## Summary
- add caching of select options in `articulos.js`
- preload dropdowns and enable `use strict`
- defer loading of `articulos.js` in `articulos.php`

## Testing
- `php -l vistas/articulos.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f02a25448327a2b3a260a097e896