### PR TITLE
Add CRUD for all plan tables

### DIFF
--- a/controlador/PlanServicioController.php
+++ b/controlador/PlanServicioController.php
@@ -1,0 +1,57 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+require_once __DIR__ . '/../modelos/PlanServicio.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$plan = new PlanServicio();
+$op   = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'guardar':
+        $ok = $plan->insertar($_POST['plan_id'] ?? '', $_POST['plan_desc'] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Plan registrado correctamente' : 'Error al registrar plan'
+        ]);
+        break;
+
+    case 'editar':
+        $ok = $plan->editar($_POST['id'] ?? '', $_POST['plan_desc'] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Plan actualizado correctamente' : 'Error al actualizar plan'
+        ]);
+        break;
+
+    case 'eliminar':
+        $ok = $plan->eliminar($_POST['plan_id'] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Plan eliminado' : 'Error al eliminar plan'
+        ]);
+        break;
+
+    case 'mostrar':
+        echo json_encode($plan->mostrar($_POST['plan_id'] ?? ''));
+        break;
+
+    case 'listar':
+        $rs   = $plan->listar();
+        $data = [];
+        while ($r = $rs->fetch_object()) {
+            $data[] = [
+                $r->plan_id,
+                htmlspecialchars($r->plan_desc),
+                '<button class="btn btn-sm btn-primary btn-edit" data-id="'.$r->plan_id.'"><i class="fa fa-edit"></i></button> '
+                .'<button class="btn btn-sm btn-danger btn-delete" data-id="'.$r->plan_id.'"><i class="fa fa-trash"></i></button>'
+            ];
+        }
+        echo json_encode(['data' => $data]);
+        break;
+
+    default:
+        echo json_encode(['data' => []]);
+        break;
+}
+?>

--- a/controlador/PlanesHorasController.php
+++ b/controlador/PlanesHorasController.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+require_once __DIR__ . '/../modelos/PlanesHoras.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$ph = new PlanesHoras();
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'guardar':
+        $ok = $ph->insertar($_POST['plan_id'] ?? '', $_POST['horas_plan'] ?? '', $_POST['plan_desc'] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro creado' : 'Error al guardar'
+        ]);
+        break;
+    case 'editar':
+        $ok = $ph->editar($_POST['id'] ?? '', $_POST['horas_plan'] ?? '', $_POST['plan_desc'] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro actualizado' : 'Error al actualizar'
+        ]);
+        break;
+    case 'eliminar':
+        $ok = $ph->eliminar($_POST['id'] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro eliminado' : 'Error al eliminar'
+        ]);
+        break;
+    case 'mostrar':
+        echo json_encode($ph->mostrar($_POST['id'] ?? ''));
+        break;
+    case 'listar':
+        $rs   = $ph->listar();
+        $data = [];
+        while ($r = $rs->fetch_object()) {
+            $data[] = [
+                $r->plan_id,
+                $r->horas_plan,
+                htmlspecialchars($r->plan_desc),
+                '<button class="btn btn-sm btn-primary btn-edit" data-id="'.$r->plan_id.'"><i class="fa fa-edit"></i></button> '
+                .'<button class="btn btn-sm btn-danger btn-delete" data-id="'.$r->plan_id.'"><i class="fa fa-trash"></i></button>'
+            ];
+        }
+        echo json_encode(['data' => $data]);
+        break;
+    default:
+        echo json_encode(['data' => []]);
+        break;
+}
+?>

--- a/controlador/PlanesPreciosController.php
+++ b/controlador/PlanesPreciosController.php
@@ -1,0 +1,71 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+require_once __DIR__ . '/../modelos/PlanesPrecios.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$pp = new PlanesPrecios();
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'guardar':
+        $ok = $pp->insertar(
+            $_POST['modelo_equipo_id'] ?? '',
+            $_POST['plan_id'] ?? '',
+            $_POST['precio_manoobra'] ?? 0,
+            $_POST['precio_materiales'] ?? 0,
+            $_POST['terceros'] ?? 0
+        );
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro creado' : 'Error al guardar'
+        ]);
+        break;
+    case 'editar':
+        $ids = explode('|', $_POST['id'] ?? '');
+        $ok = $pp->editar(
+            $ids[0] ?? '',
+            $ids[1] ?? '',
+            $_POST['precio_manoobra'] ?? 0,
+            $_POST['precio_materiales'] ?? 0,
+            $_POST['terceros'] ?? 0
+        );
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro actualizado' : 'Error al actualizar'
+        ]);
+        break;
+    case 'eliminar':
+        $ids = explode('|', $_POST['id'] ?? '');
+        $ok  = $pp->eliminar($ids[0] ?? '', $ids[1] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro eliminado' : 'Error al eliminar'
+        ]);
+        break;
+    case 'mostrar':
+        $ids = explode('|', $_POST['id'] ?? '');
+        echo json_encode($pp->mostrar($ids[0] ?? '', $ids[1] ?? ''));
+        break;
+    case 'listar':
+        $rs   = $pp->listar();
+        $data = [];
+        while ($r = $rs->fetch_object()) {
+            $id = $r->modelo_equipo_id.'|'.$r->plan_id;
+            $data[] = [
+                $r->modelo_equipo_id,
+                $r->plan_id,
+                $r->precio_manoobra,
+                $r->precio_materiales,
+                $r->terceros,
+                '<button class="btn btn-sm btn-primary btn-edit" data-id="'.$id.'"><i class="fa fa-edit"></i></button> '
+                .'<button class="btn btn-sm btn-danger btn-delete" data-id="'.$id.'"><i class="fa fa-trash"></i></button>'
+            ];
+        }
+        echo json_encode(['data' => $data]);
+        break;
+    default:
+        echo json_encode(['data' => []]);
+        break;
+}
+?>

--- a/controlador/PlanesPreciosServiciosController.php
+++ b/controlador/PlanesPreciosServiciosController.php
@@ -1,0 +1,97 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+require_once __DIR__ . '/../modelos/PlanesPreciosServicios.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$pps = new PlanesPreciosServicios();
+$op = $_GET['op'] ?? '';
+
+switch ($op) {
+    case 'guardar':
+        $data = [
+            $_POST['modelo_equipo_id'] ?? '',
+            $_POST['plana_manoobra'] ?? 0,
+            $_POST['plana_materiales'] ?? 0,
+            $_POST['plana_terceros'] ?? 0,
+            $_POST['planb_manoobra'] ?? 0,
+            $_POST['planb_materiales'] ?? 0,
+            $_POST['planb_terceros'] ?? 0,
+            $_POST['planc_manoobra'] ?? 0,
+            $_POST['planc_materiales'] ?? 0,
+            $_POST['planc_terceros'] ?? 0,
+            $_POST['pland_manoobra'] ?? 0,
+            $_POST['pland_materiales'] ?? 0,
+            $_POST['pland_terceros'] ?? 0,
+            $_POST['plan_semestral_manoobra'] ?? 0,
+            $_POST['plan_semestral_materiales'] ?? 0,
+            $_POST['plan_semestral_terceros'] ?? 0,
+            $_POST['plan_anual_manoobra'] ?? 0,
+            $_POST['plan_anual_materiales'] ?? 0,
+            $_POST['plan_anual_terceros'] ?? 0
+        ];
+        $ok = $pps->insertar($data);
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro creado' : 'Error al guardar'
+        ]);
+        break;
+    case 'editar':
+        $id   = $_POST['id'] ?? '';
+        $data = [
+            $_POST['plana_manoobra'] ?? 0,
+            $_POST['plana_materiales'] ?? 0,
+            $_POST['plana_terceros'] ?? 0,
+            $_POST['planb_manoobra'] ?? 0,
+            $_POST['planb_materiales'] ?? 0,
+            $_POST['planb_terceros'] ?? 0,
+            $_POST['planc_manoobra'] ?? 0,
+            $_POST['planc_materiales'] ?? 0,
+            $_POST['planc_terceros'] ?? 0,
+            $_POST['pland_manoobra'] ?? 0,
+            $_POST['pland_materiales'] ?? 0,
+            $_POST['pland_terceros'] ?? 0,
+            $_POST['plan_semestral_manoobra'] ?? 0,
+            $_POST['plan_semestral_materiales'] ?? 0,
+            $_POST['plan_semestral_terceros'] ?? 0,
+            $_POST['plan_anual_manoobra'] ?? 0,
+            $_POST['plan_anual_materiales'] ?? 0,
+            $_POST['plan_anual_terceros'] ?? 0
+        ];
+        $ok = $pps->editar($id, $data);
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro actualizado' : 'Error al actualizar'
+        ]);
+        break;
+    case 'eliminar':
+        $ok = $pps->eliminar($_POST['id'] ?? '');
+        echo json_encode([
+            'status' => $ok ? 'success' : 'error',
+            'msg'    => $ok ? 'Registro eliminado' : 'Error al eliminar'
+        ]);
+        break;
+    case 'mostrar':
+        echo json_encode($pps->mostrar($_POST['id'] ?? ''));
+        break;
+    case 'listar':
+        $rs   = $pps->listar();
+        $data = [];
+        while ($r = $rs->fetch_object()) {
+            $data[] = [
+                $r->modelo_equipo_id,
+                $r->plana_manoobra,
+                $r->planb_manoobra,
+                $r->planc_manoobra,
+                $r->pland_manoobra,
+                '<button class="btn btn-sm btn-primary btn-edit" data-id="'.$r->modelo_equipo_id.'"><i class="fa fa-edit"></i></button> '
+                .'<button class="btn btn-sm btn-danger btn-delete" data-id="'.$r->modelo_equipo_id.'"><i class="fa fa-trash"></i></button>'
+            ];
+        }
+        echo json_encode(['data' => $data]);
+        break;
+    default:
+        echo json_encode(['data' => []]);
+        break;
+}
+?>

--- a/modelos/PlanServicio.php
+++ b/modelos/PlanServicio.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class PlanServicio
+{
+    public function insertar($plan_id, $descripcion)
+    {
+        $plan_id     = limpiarCadena($plan_id);
+        $descripcion = limpiarCadena($descripcion);
+        $sql = "INSERT INTO planes_servicio (plan_id, plan_desc) VALUES (?, ?)";
+        return ejecutarConsulta($sql, [$plan_id, $descripcion]);
+    }
+
+    public function editar($plan_id, $descripcion)
+    {
+        $plan_id     = limpiarCadena($plan_id);
+        $descripcion = limpiarCadena($descripcion);
+        $sql = "UPDATE planes_servicio SET plan_desc = ? WHERE plan_id = ?";
+        return ejecutarConsulta($sql, [$descripcion, $plan_id]);
+    }
+
+    public function eliminar($plan_id)
+    {
+        $plan_id = limpiarCadena($plan_id);
+        $sql = "DELETE FROM planes_servicio WHERE plan_id = ?";
+        return ejecutarConsulta($sql, [$plan_id]);
+    }
+
+    public function mostrar($plan_id)
+    {
+        $plan_id = limpiarCadena($plan_id);
+        $sql = "SELECT plan_id, plan_desc FROM planes_servicio WHERE plan_id = ?";
+        return ejecutarConsultaSimpleFila($sql, [$plan_id]);
+    }
+
+    public function listar()
+    {
+        $sql = "SELECT plan_id, plan_desc FROM planes_servicio ORDER BY plan_id";
+        return ejecutarConsulta($sql);
+    }
+}
+?>

--- a/modelos/PlanesHoras.php
+++ b/modelos/PlanesHoras.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class PlanesHoras
+{
+    public function insertar($plan_id, $horas_plan, $plan_desc)
+    {
+        $plan_id    = limpiarCadena($plan_id);
+        $horas_plan = limpiarCadena($horas_plan);
+        $plan_desc  = limpiarCadena($plan_desc);
+        $sql = "INSERT INTO planes_horas (plan_id, horas_plan, plan_desc) VALUES (?, ?, ?)";
+        return ejecutarConsulta($sql, [$plan_id, $horas_plan, $plan_desc]);
+    }
+
+    public function editar($plan_id, $horas_plan, $plan_desc)
+    {
+        $plan_id    = limpiarCadena($plan_id);
+        $horas_plan = limpiarCadena($horas_plan);
+        $plan_desc  = limpiarCadena($plan_desc);
+        $sql = "UPDATE planes_horas SET horas_plan = ?, plan_desc = ? WHERE plan_id = ?";
+        return ejecutarConsulta($sql, [$horas_plan, $plan_desc, $plan_id]);
+    }
+
+    public function eliminar($plan_id)
+    {
+        $plan_id = limpiarCadena($plan_id);
+        $sql = "DELETE FROM planes_horas WHERE plan_id = ?";
+        return ejecutarConsulta($sql, [$plan_id]);
+    }
+
+    public function mostrar($plan_id)
+    {
+        $plan_id = limpiarCadena($plan_id);
+        $sql = "SELECT plan_id, horas_plan, plan_desc FROM planes_horas WHERE plan_id = ?";
+        return ejecutarConsultaSimpleFila($sql, [$plan_id]);
+    }
+
+    public function listar()
+    {
+        $sql = "SELECT plan_id, horas_plan, plan_desc FROM planes_horas ORDER BY plan_id";
+        return ejecutarConsulta($sql);
+    }
+}
+?>

--- a/modelos/PlanesPrecios.php
+++ b/modelos/PlanesPrecios.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class PlanesPrecios
+{
+    public function insertar($modelo_equipo_id, $plan_id, $mano, $mat, $terc)
+    {
+        $sql = "INSERT INTO planes_precios (modelo_equipo_id, plan_id, precio_manoobra, precio_materiales, terceros) VALUES (?, ?, ?, ?, ?)";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($modelo_equipo_id),
+            limpiarCadena($plan_id),
+            limpiarCadena($mano),
+            limpiarCadena($mat),
+            limpiarCadena($terc)
+        ]);
+    }
+
+    public function editar($modelo_equipo_id, $plan_id, $mano, $mat, $terc)
+    {
+        $sql = "UPDATE planes_precios SET precio_manoobra=?, precio_materiales=?, terceros=? WHERE modelo_equipo_id=? AND plan_id=?";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($mano),
+            limpiarCadena($mat),
+            limpiarCadena($terc),
+            limpiarCadena($modelo_equipo_id),
+            limpiarCadena($plan_id)
+        ]);
+    }
+
+    public function eliminar($modelo_equipo_id, $plan_id)
+    {
+        $sql = "DELETE FROM planes_precios WHERE modelo_equipo_id=? AND plan_id=?";
+        return ejecutarConsulta($sql, [
+            limpiarCadena($modelo_equipo_id),
+            limpiarCadena($plan_id)
+        ]);
+    }
+
+    public function mostrar($modelo_equipo_id, $plan_id)
+    {
+        $sql = "SELECT * FROM planes_precios WHERE modelo_equipo_id=? AND plan_id=?";
+        return ejecutarConsultaSimpleFila($sql, [
+            limpiarCadena($modelo_equipo_id),
+            limpiarCadena($plan_id)
+        ]);
+    }
+
+    public function listar()
+    {
+        $sql = "SELECT modelo_equipo_id, plan_id, precio_manoobra, precio_materiales, terceros FROM planes_precios";
+        return ejecutarConsulta($sql);
+    }
+}
+?>

--- a/modelos/PlanesPreciosServicios.php
+++ b/modelos/PlanesPreciosServicios.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/../config/Conexion.php';
+
+class PlanesPreciosServicios
+{
+    public function insertar($data)
+    {
+        $sql = "INSERT INTO planes_precios_servicios (
+            modelo_equipo_id, plana_manoobra, plana_materiales, plana_terceros,
+            planb_manoobra, planb_materiales, planb_terceros,
+            planc_manoobra, planc_materiales, planc_terceros,
+            pland_manoobra, pland_materiales, pland_terceros,
+            plan_semestral_manoobra, plan_semestral_materiales, plan_semestral_terceros,
+            plan_anual_manoobra, plan_anual_materiales, plan_anual_terceros
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+        $params = array_map('limpiarCadena', $data);
+        return ejecutarConsulta($sql, $params);
+    }
+
+    public function editar($modelo_equipo_id, $data)
+    {
+        $sql = "UPDATE planes_precios_servicios SET
+            plana_manoobra=?, plana_materiales=?, plana_terceros=?,
+            planb_manoobra=?, planb_materiales=?, planb_terceros=?,
+            planc_manoobra=?, planc_materiales=?, planc_terceros=?,
+            pland_manoobra=?, pland_materiales=?, pland_terceros=?,
+            plan_semestral_manoobra=?, plan_semestral_materiales=?, plan_semestral_terceros=?,
+            plan_anual_manoobra=?, plan_anual_materiales=?, plan_anual_terceros=?
+            WHERE modelo_equipo_id=?";
+        $params = array_map('limpiarCadena', $data);
+        $params[] = limpiarCadena($modelo_equipo_id);
+        return ejecutarConsulta($sql, $params);
+    }
+
+    public function eliminar($modelo_equipo_id)
+    {
+        $sql = "DELETE FROM planes_precios_servicios WHERE modelo_equipo_id=?";
+        return ejecutarConsulta($sql, [limpiarCadena($modelo_equipo_id)]);
+    }
+
+    public function mostrar($modelo_equipo_id)
+    {
+        $sql = "SELECT * FROM planes_precios_servicios WHERE modelo_equipo_id=?";
+        return ejecutarConsultaSimpleFila($sql, [limpiarCadena($modelo_equipo_id)]);
+    }
+
+    public function listar()
+    {
+        $sql = "SELECT modelo_equipo_id, plana_manoobra, planb_manoobra, planc_manoobra, pland_manoobra FROM planes_precios_servicios";
+        return ejecutarConsulta($sql);
+    }
+}
+?>

--- a/vistas/js/planServicio.js
+++ b/vistas/js/planServicio.js
@@ -1,0 +1,51 @@
+// vistas/js/planServicio.js
+$(function(){
+  function crud(cfg){
+    const table = $(cfg.table).DataTable({
+      ajax:{ url: BASE_URL+'controlador/'+cfg.ctrl+'?op=listar', dataSrc:'data' }
+    });
+    $(cfg.btnNew).on('click',()=>{
+      $(cfg.form)[0].reset();
+      $(cfg.form+' [name=id]').val('');
+      $(cfg.modal+' .modal-title').text(cfg.title);
+      $(cfg.modal).modal('show');
+    });
+    $(cfg.table).on('click','.btn-edit',function(){
+      const id=$(this).data('id');
+      $.post(BASE_URL+'controlador/'+cfg.ctrl+'?op=mostrar',{id},r=>{
+        if(!r) return;
+        Object.keys(r).forEach(k=>$(cfg.form+' [name='+k+']').val(r[k]));
+        $(cfg.form+' [name=id]').val(id);
+        $(cfg.modal+' .modal-title').text(cfg.title);
+        $(cfg.modal).modal('show');
+      },'json');
+    });
+    $(cfg.table).on('click','.btn-delete',function(){
+      const id=$(this).data('id');
+      Swal.fire({title:'¿Eliminar?',icon:'warning',showCancelButton:true})
+        .then(res=>{ if(res.isConfirmed){
+          $.post(BASE_URL+'controlador/'+cfg.ctrl+'?op=eliminar',{id},resp=>{
+            Swal.fire('',resp.msg,resp.status); table.ajax.reload();
+          },'json');
+        }});
+    });
+    $(cfg.form).on('submit',function(e){
+      e.preventDefault();
+      const op=$(cfg.form+' [name=id]').val()? 'editar':'guardar';
+      $.post(BASE_URL+'controlador/'+cfg.ctrl+'?op='+op,$(this).serialize(),resp=>{
+        if(resp.status==='success'){
+          $(cfg.modal).modal('hide');
+          Swal.fire('Éxito',resp.msg,'success');
+          table.ajax.reload();
+        }else{
+          Swal.fire('Error',resp.msg||'Ocurrió un error','error');
+        }
+      },'json');
+    });
+  }
+
+  crud({table:'#tblPlanServicio',form:'#formPlanServicio',modal:'#modalPlanServicio',btnNew:'#btnNewServ',ctrl:'PlanServicioController.php',title:'Plan Servicio'});
+  crud({table:'#tblPlanesHoras',form:'#formPlanesHoras',modal:'#modalPlanesHoras',btnNew:'#btnNewHoras',ctrl:'PlanesHorasController.php',title:'Plan Horas'});
+  crud({table:'#tblPlanesPrecios',form:'#formPlanesPrecios',modal:'#modalPlanesPrecios',btnNew:'#btnNewPrecios',ctrl:'PlanesPreciosController.php',title:'Plan Precio'});
+  crud({table:'#tblPlanesPreciosServ',form:'#formPlanesPreciosServ',modal:'#modalPlanesPreciosServ',btnNew:'#btnNewPS',ctrl:'PlanesPreciosServiciosController.php',title:'Precios Servicio'});
+});

--- a/vistas/planServicio.php
+++ b/vistas/planServicio.php
@@ -1,0 +1,294 @@
+<?php $pageTitle = 'Gestión de Planes'; ?>
+<?php require 'layout/header.php'; ?>
+<?php require 'layout/navbar.php'; ?>
+<?php require 'layout/sidebar.php'; ?>
+<div class="container-fluid pt-4">
+  <h3 class="mb-3"><?= htmlspecialchars($pageTitle) ?></h3>
+  <ul class="nav nav-tabs">
+    <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#tabServ">Planes Servicio</a></li>
+    <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#tabHoras">Planes Horas</a></li>
+    <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#tabPrecios">Planes Precios</a></li>
+    <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#tabPS">Precios Servicios</a></li>
+  </ul>
+  <div class="tab-content pt-3">
+    <!-- Planes Servicio -->
+    <div id="tabServ" class="tab-pane fade show active">
+      <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span class="fw-bold">Planes Servicio</span>
+          <button id="btnNewServ" class="btn btn-success">+ Nuevo</button>
+        </div>
+        <div class="card-body">
+          <table id="tblPlanServicio" class="table table-striped w-100">
+            <thead>
+              <tr><th>ID</th><th>Descripción</th><th>Acción</th></tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <!-- Planes Horas -->
+    <div id="tabHoras" class="tab-pane fade">
+      <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span class="fw-bold">Planes Horas</span>
+          <button id="btnNewHoras" class="btn btn-success">+ Nuevo</button>
+        </div>
+        <div class="card-body">
+          <table id="tblPlanesHoras" class="table table-striped w-100">
+            <thead>
+              <tr><th>ID</th><th>Horas</th><th>Descripción</th><th>Acción</th></tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <!-- Planes Precios -->
+    <div id="tabPrecios" class="tab-pane fade">
+      <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span class="fw-bold">Planes Precios</span>
+          <button id="btnNewPrecios" class="btn btn-success">+ Nuevo</button>
+        </div>
+        <div class="card-body">
+          <table id="tblPlanesPrecios" class="table table-striped w-100">
+            <thead>
+              <tr>
+                <th>Modelo</th><th>Plan</th><th>Mano Obra</th><th>Materiales</th><th>Terceros</th><th>Acción</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <!-- Planes Precios Servicios -->
+    <div id="tabPS" class="tab-pane fade">
+      <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span class="fw-bold">Precios por Servicio</span>
+          <button id="btnNewPS" class="btn btn-success">+ Nuevo</button>
+        </div>
+        <div class="card-body">
+          <table id="tblPlanesPreciosServ" class="table table-striped w-100">
+            <thead>
+              <tr>
+                <th>Modelo</th><th>Plan A</th><th>Plan B</th><th>Plan C</th><th>Plan D</th><th>Acción</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modales -->
+<div class="modal fade" id="modalPlanServicio" tabindex="-1">
+  <div class="modal-dialog">
+    <form id="formPlanServicio" class="modal-content">
+      <div class="modal-header bg-primary text-white">
+        <h5 class="modal-title">Plan Servicio</h5>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="id">
+        <div class="form-group">
+          <label>ID</label>
+          <input type="text" name="plan_id" class="form-control" maxlength="2" required>
+        </div>
+        <div class="form-group">
+          <label>Descripción</label>
+          <input type="text" name="plan_desc" class="form-control" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-light">Guardar</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="modal fade" id="modalPlanesHoras" tabindex="-1">
+  <div class="modal-dialog">
+    <form id="formPlanesHoras" class="modal-content">
+      <div class="modal-header bg-primary text-white">
+        <h5 class="modal-title">Plan Horas</h5>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="id">
+        <div class="form-group">
+          <label>ID</label>
+          <input type="text" name="plan_id" class="form-control" maxlength="2" required>
+        </div>
+        <div class="form-group">
+          <label>Horas</label>
+          <input type="number" name="horas_plan" class="form-control" required>
+        </div>
+        <div class="form-group">
+          <label>Descripción</label>
+          <input type="text" name="plan_desc" class="form-control">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-light">Guardar</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="modal fade" id="modalPlanesPrecios" tabindex="-1">
+  <div class="modal-dialog">
+    <form id="formPlanesPrecios" class="modal-content">
+      <div class="modal-header bg-primary text-white">
+        <h5 class="modal-title">Plan Precio</h5>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="id">
+        <div class="form-group">
+          <label>Modelo Equipo</label>
+          <input type="number" name="modelo_equipo_id" class="form-control" required>
+        </div>
+        <div class="form-group">
+          <label>Plan</label>
+          <input type="text" name="plan_id" class="form-control" maxlength="2" required>
+        </div>
+        <div class="form-group">
+          <label>Mano de Obra</label>
+          <input type="number" step="0.01" name="precio_manoobra" class="form-control">
+        </div>
+        <div class="form-group">
+          <label>Materiales</label>
+          <input type="number" step="0.01" name="precio_materiales" class="form-control">
+        </div>
+        <div class="form-group">
+          <label>Terceros</label>
+          <input type="number" step="0.01" name="terceros" class="form-control">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-light">Guardar</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="modal fade" id="modalPlanesPreciosServ" tabindex="-1">
+  <div class="modal-dialog">
+    <form id="formPlanesPreciosServ" class="modal-content">
+      <div class="modal-header bg-primary text-white">
+        <h5 class="modal-title">Precios Servicio</h5>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body" style="max-height:60vh;overflow:auto;">
+        <input type="hidden" name="id">
+        <div class="form-group">
+          <label>Modelo Equipo</label>
+          <input type="number" name="modelo_equipo_id" class="form-control" required>
+        </div>
+        <div class="row">
+          <div class="col-md-4">
+            <label>Plan A Mano Obra</label>
+            <input type="number" step="0.01" name="plana_manoobra" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan A Materiales</label>
+            <input type="number" step="0.01" name="plana_materiales" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan A Terceros</label>
+            <input type="number" step="0.01" name="plana_terceros" class="form-control">
+          </div>
+        </div>
+        <div class="row mt-2">
+          <div class="col-md-4">
+            <label>Plan B Mano Obra</label>
+            <input type="number" step="0.01" name="planb_manoobra" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan B Materiales</label>
+            <input type="number" step="0.01" name="planb_materiales" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan B Terceros</label>
+            <input type="number" step="0.01" name="planb_terceros" class="form-control">
+          </div>
+        </div>
+        <div class="row mt-2">
+          <div class="col-md-4">
+            <label>Plan C Mano Obra</label>
+            <input type="number" step="0.01" name="planc_manoobra" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan C Materiales</label>
+            <input type="number" step="0.01" name="planc_materiales" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan C Terceros</label>
+            <input type="number" step="0.01" name="planc_terceros" class="form-control">
+          </div>
+        </div>
+        <div class="row mt-2">
+          <div class="col-md-4">
+            <label>Plan D Mano Obra</label>
+            <input type="number" step="0.01" name="pland_manoobra" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan D Materiales</label>
+            <input type="number" step="0.01" name="pland_materiales" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Plan D Terceros</label>
+            <input type="number" step="0.01" name="pland_terceros" class="form-control">
+          </div>
+        </div>
+        <div class="row mt-2">
+          <div class="col-md-4">
+            <label>Semestral Mano Obra</label>
+            <input type="number" step="0.01" name="plan_semestral_manoobra" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Semestral Materiales</label>
+            <input type="number" step="0.01" name="plan_semestral_materiales" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Semestral Terceros</label>
+            <input type="number" step="0.01" name="plan_semestral_terceros" class="form-control">
+          </div>
+        </div>
+        <div class="row mt-2">
+          <div class="col-md-4">
+            <label>Anual Mano Obra</label>
+            <input type="number" step="0.01" name="plan_anual_manoobra" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Anual Materiales</label>
+            <input type="number" step="0.01" name="plan_anual_materiales" class="form-control">
+          </div>
+          <div class="col-md-4">
+            <label>Anual Terceros</label>
+            <input type="number" step="0.01" name="plan_anual_terceros" class="form-control">
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-light">Guardar</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<?php require 'layout/footer.php'; ?>
+<script>
+  const BASE_URL = '<?= APP_URL ?>';
+</script>
+<script src="<?= APP_URL ?>vistas/js/planServicio.js"></script>


### PR DESCRIPTION
## Summary
- implement controllers and models for planes_horas, planes_precios and planes_precios_servicios
- rewrite planServicio view to handle CRUD for four tables using tabs
- simplify JS to manage all CRUD operations

## Testing
- `php -l controlador/PlanesHorasController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d086b63083279cc99e8845798160