### PR TITLE
Mejora registro de Planes de Servicio

### DIFF
--- a/controlador/PlanServicioController.php
+++ b/controlador/PlanServicioController.php
@@ -9,7 +9,7 @@ $op   = $_GET['op'] ?? '';
 
 switch ($op) {
     case 'guardar':
-        $ok = $plan->insertar($_POST['plan_id'] ?? '', $_POST['plan_desc'] ?? '');
+        $ok = $plan->insertar($_POST['plan_desc'] ?? '');
         echo json_encode([
             'status' => $ok ? 'success' : 'error',
             'msg'    => $ok ? 'Plan registrado correctamente' : 'Error al registrar plan'
@@ -25,7 +25,7 @@ switch ($op) {
         break;
 
     case 'eliminar':
-        $ok = $plan->eliminar($_POST['plan_id'] ?? '');
+        $ok = $plan->eliminar($_POST['id'] ?? '');
         echo json_encode([
             'status' => $ok ? 'success' : 'error',
             'msg'    => $ok ? 'Plan eliminado' : 'Error al eliminar plan'
@@ -33,7 +33,11 @@ switch ($op) {
         break;
 
     case 'mostrar':
-        echo json_encode($plan->mostrar($_POST['plan_id'] ?? ''));
+        echo json_encode($plan->mostrar($_POST['id'] ?? ''));
+        break;
+
+    case 'combo':
+        echo json_encode($plan->listarCombo());
         break;
 
     case 'listar':

--- a/modelos/PlanServicio.php
+++ b/modelos/PlanServicio.php
@@ -3,12 +3,24 @@ require_once __DIR__ . '/../config/Conexion.php';
 
 class PlanServicio
 {
-    public function insertar($plan_id, $descripcion)
+    public function insertar($descripcion)
     {
-        $plan_id     = limpiarCadena($plan_id);
         $descripcion = limpiarCadena($descripcion);
+        $plan_id     = $this->generarId();
         $sql = "INSERT INTO planes_servicio (plan_id, plan_desc) VALUES (?, ?)";
         return ejecutarConsulta($sql, [$plan_id, $descripcion]);
+    }
+
+    private function generarId()
+    {
+        $sql  = "SELECT MAX(plan_id) AS max_id FROM planes_servicio";
+        $resp = ejecutarConsultaSimpleFila($sql);
+        $max  = $resp['max_id'] ?? null;
+        if (!$max) {
+            return 'A';
+        }
+        $next = chr(ord($max) + 1);
+        return $next;
     }
 
     public function editar($plan_id, $descripcion)
@@ -37,6 +49,12 @@ class PlanServicio
     {
         $sql = "SELECT plan_id, plan_desc FROM planes_servicio ORDER BY plan_id";
         return ejecutarConsulta($sql);
+    }
+
+    public function listarCombo()
+    {
+        $sql = "SELECT plan_id, plan_desc FROM planes_servicio ORDER BY plan_id";
+        return ejecutarConsultaArray($sql);
     }
 }
 ?>

--- a/vistas/js/planServicio.js
+++ b/vistas/js/planServicio.js
@@ -1,12 +1,23 @@
 // vistas/js/planServicio.js
 $(function(){
+  function loadPlanes(){
+    $.getJSON(BASE_URL+'controlador/PlanServicioController.php?op=combo',r=>{
+      const opts=r.map(p=>`<option value="${p.plan_id}">${p.plan_desc}</option>`).join('');
+      $('#formPlanesHoras select[name=plan_id],#formPlanesPrecios select[name=plan_id]').html(opts);
+    });
+  }
+
   function crud(cfg){
-    const table = $(cfg.table).DataTable({
-      ajax:{ url: BASE_URL+'controlador/'+cfg.ctrl+'?op=listar', dataSrc:'data' }
+    const table=$(cfg.table).DataTable({
+      ajax:{url:BASE_URL+'controlador/'+cfg.ctrl+'?op=listar',dataSrc:'data'}
     });
     $(cfg.btnNew).on('click',()=>{
       $(cfg.form)[0].reset();
       $(cfg.form+' [name=id]').val('');
+      if(cfg.ctrl==='PlanServicioController.php'){
+        $('#groupPlanId').hide();
+        $('#groupPlanId input').prop('disabled',true);
+      }
       $(cfg.modal+' .modal-title').text(cfg.title);
       $(cfg.modal).modal('show');
     });
@@ -16,6 +27,10 @@ $(function(){
         if(!r) return;
         Object.keys(r).forEach(k=>$(cfg.form+' [name='+k+']').val(r[k]));
         $(cfg.form+' [name=id]').val(id);
+        if(cfg.ctrl==='PlanServicioController.php'){
+          $('#groupPlanId').show();
+          $('#groupPlanId input').prop('disabled',true);
+        }
         $(cfg.modal+' .modal-title').text(cfg.title);
         $(cfg.modal).modal('show');
       },'json');
@@ -26,6 +41,7 @@ $(function(){
         .then(res=>{ if(res.isConfirmed){
           $.post(BASE_URL+'controlador/'+cfg.ctrl+'?op=eliminar',{id},resp=>{
             Swal.fire('',resp.msg,resp.status); table.ajax.reload();
+            if(cfg.ctrl==='PlanServicioController.php') loadPlanes();
           },'json');
         }});
     });
@@ -37,6 +53,7 @@ $(function(){
           $(cfg.modal).modal('hide');
           Swal.fire('Éxito',resp.msg,'success');
           table.ajax.reload();
+          if(cfg.ctrl==='PlanServicioController.php') loadPlanes();
         }else{
           Swal.fire('Error',resp.msg||'Ocurrió un error','error');
         }
@@ -44,6 +61,7 @@ $(function(){
     });
   }
 
+  loadPlanes();
   crud({table:'#tblPlanServicio',form:'#formPlanServicio',modal:'#modalPlanServicio',btnNew:'#btnNewServ',ctrl:'PlanServicioController.php',title:'Plan Servicio'});
   crud({table:'#tblPlanesHoras',form:'#formPlanesHoras',modal:'#modalPlanesHoras',btnNew:'#btnNewHoras',ctrl:'PlanesHorasController.php',title:'Plan Horas'});
   crud({table:'#tblPlanesPrecios',form:'#formPlanesPrecios',modal:'#modalPlanesPrecios',btnNew:'#btnNewPrecios',ctrl:'PlanesPreciosController.php',title:'Plan Precio'});

--- a/vistas/planServicio.php
+++ b/vistas/planServicio.php
@@ -96,9 +96,9 @@
       </div>
       <div class="modal-body">
         <input type="hidden" name="id">
-        <div class="form-group">
+        <div class="form-group" id="groupPlanId">
           <label>ID</label>
-          <input type="text" name="plan_id" class="form-control" maxlength="2" required>
+          <input type="text" name="plan_id" class="form-control" maxlength="2">
         </div>
         <div class="form-group">
           <label>Descripción</label>
@@ -123,8 +123,8 @@
       <div class="modal-body">
         <input type="hidden" name="id">
         <div class="form-group">
-          <label>ID</label>
-          <input type="text" name="plan_id" class="form-control" maxlength="2" required>
+          <label>Plan</label>
+          <select name="plan_id" class="form-control"></select>
         </div>
         <div class="form-group">
           <label>Horas</label>
@@ -158,7 +158,7 @@
         </div>
         <div class="form-group">
           <label>Plan</label>
-          <input type="text" name="plan_id" class="form-control" maxlength="2" required>
+          <select name="plan_id" class="form-control"></select>
         </div>
         <div class="form-group">
           <label>Mano de Obra</label>


### PR DESCRIPTION
## Summary
- generar automáticamente el ID de un plan de servicio
- exponer endpoint `combo` para obtener listado de planes
- permitir seleccionar planes en PlanesHoras y PlanesPrecios
- actualizar interfaz para ocultar el ID al crear un plan

## Testing
- `php` was not available so syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_6868d570be4483279d1529f86029ba4c